### PR TITLE
[feat] #7 - 커스텀 응답 및 예외 처리, 프로젝트 세팅 수정, API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,46 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### macOS template ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# ignore application.yml
+*.yml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,27 @@ repositories {
 }
 
 dependencies {
+	// Spring
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	// Database
+	runtimeOnly 'mysql:mysql-connector-java:8.0.32'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// Junit
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 	implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
 	implementation 'org.hibernate:hibernate-core:6.3.2.Final'
 }

--- a/src/main/java/com/safetyreport/SafetyreportApplication.java
+++ b/src/main/java/com/safetyreport/SafetyreportApplication.java
@@ -1,4 +1,4 @@
-package com.safetyreport.safetyreport;
+package com.safetyreport;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/safetyreport/domain/api/ReportController.java
+++ b/src/main/java/com/safetyreport/domain/api/ReportController.java
@@ -1,0 +1,55 @@
+package com.safetyreport.domain.api;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.safetyreport.domain.api.dto.response.CategoryDetail;
+import com.safetyreport.domain.api.dto.response.CategoryRetrieveResponse;
+import com.safetyreport.domain.api.dto.response.PhotoDetail;
+import com.safetyreport.domain.api.dto.response.PhotoRetrieveResponse;
+import com.safetyreport.domain.service.ReportService;
+import com.safetyreport.domain.service.domain.Category;
+import com.safetyreport.domain.service.domain.Photo;
+import com.safetyreport.global.exception.code.SuccessCode;
+import com.safetyreport.global.exception.dto.SuccessResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/report")
+@RequiredArgsConstructor
+public class ReportController {
+
+	private final ReportService reportService;
+
+	@GetMapping("/category")
+	ResponseEntity<SuccessResponse<CategoryRetrieveResponse>> getCategoryList(){
+		List<Category> categoryList = reportService.getCategoryList();
+
+		List<CategoryDetail> categoryDetailList = categoryList.stream()
+			.map(category -> new CategoryDetail(category.getId(), category.getName(), category.getDescription()))
+			.toList();
+
+		return ResponseEntity.ok(
+			SuccessResponse.of(SuccessCode.SUCCESS_FETCH, CategoryRetrieveResponse.of(categoryDetailList)));
+	}
+
+	@GetMapping("/photo")
+	ResponseEntity<SuccessResponse<PhotoRetrieveResponse>> getPhotoList(
+		@RequestHeader final Long userId
+	){
+		List<Photo> photoList = reportService.getPhotoList(userId);
+
+		List<PhotoDetail> photoDetailList = photoList.stream()
+			.map(photo -> new PhotoDetail(photo.getId(), photo.getPhotoUrl(), photo.getCreatedAt()))
+			.toList();
+
+		return ResponseEntity.ok(
+			SuccessResponse.of(SuccessCode.SUCCESS_FETCH, PhotoRetrieveResponse.of(photoDetailList)));
+	}
+}

--- a/src/main/java/com/safetyreport/domain/api/dto/response/CategoryDetail.java
+++ b/src/main/java/com/safetyreport/domain/api/dto/response/CategoryDetail.java
@@ -1,0 +1,8 @@
+package com.safetyreport.domain.api.dto.response;
+
+public record CategoryDetail(
+	long categoryId,
+	String categoryName,
+	String categoryDescription
+) {
+}

--- a/src/main/java/com/safetyreport/domain/api/dto/response/CategoryRetrieveResponse.java
+++ b/src/main/java/com/safetyreport/domain/api/dto/response/CategoryRetrieveResponse.java
@@ -1,0 +1,11 @@
+package com.safetyreport.domain.api.dto.response;
+
+import java.util.List;
+
+public record CategoryRetrieveResponse(
+	List<CategoryDetail> categoryDetailList
+) {
+	public static CategoryRetrieveResponse of(List<CategoryDetail> categoryDetailList) {
+		return new CategoryRetrieveResponse(categoryDetailList);
+	}
+}

--- a/src/main/java/com/safetyreport/domain/api/dto/response/PhotoDetail.java
+++ b/src/main/java/com/safetyreport/domain/api/dto/response/PhotoDetail.java
@@ -1,0 +1,10 @@
+package com.safetyreport.domain.api.dto.response;
+
+import java.time.LocalDateTime;
+
+public record PhotoDetail(
+	long photoId,
+	String photoUrl,
+	LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/safetyreport/domain/api/dto/response/PhotoRetrieveResponse.java
+++ b/src/main/java/com/safetyreport/domain/api/dto/response/PhotoRetrieveResponse.java
@@ -1,0 +1,11 @@
+package com.safetyreport.domain.api.dto.response;
+
+import java.util.List;
+
+public record PhotoRetrieveResponse(
+	List<PhotoDetail> photoList
+) {
+	public static PhotoRetrieveResponse of(List<PhotoDetail> photoList) {
+		return new PhotoRetrieveResponse(photoList);
+	}
+}

--- a/src/main/java/com/safetyreport/domain/entity/BannerEntity.java
+++ b/src/main/java/com/safetyreport/domain/entity/BannerEntity.java
@@ -1,4 +1,4 @@
-package com.safetyreport.safetyreport.domain.entity;
+package com.safetyreport.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -9,13 +9,15 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Table(name = "banner")
 public class BannerEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long id;
+    @Column(name = "id")
+    private Long id;
 
-    @Column(name = "banner_url")
-    public String bannerUrl;
+    @Column(name = "banner_url", nullable = false)
+    private String bannerUrl;
 
     @Builder
     public BannerEntity(String bannerUrl, Long id) {

--- a/src/main/java/com/safetyreport/domain/entity/CategoryEntity.java
+++ b/src/main/java/com/safetyreport/domain/entity/CategoryEntity.java
@@ -1,4 +1,4 @@
-package com.safetyreport.safetyreport.domain.entity;
+package com.safetyreport.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -8,16 +8,18 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Table(name = "category")
 public class CategoryEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long id;
+    @Column(name = "id")
+    private Long id;
 
-    @Column(name = "category_name")
-    public String name;
+    @Column(name = "name", nullable = false)
+    private String name;
 
-    @Column(name = "category_description")
-    public String description;
+    @Column(name = "description", nullable = false)
+    private String description;
 
     public CategoryEntity(String description, Long id, String name) {
         this.description = description;

--- a/src/main/java/com/safetyreport/domain/entity/PhotoEntity.java
+++ b/src/main/java/com/safetyreport/domain/entity/PhotoEntity.java
@@ -1,4 +1,7 @@
-package com.safetyreport.safetyreport.domain.entity;
+package com.safetyreport.domain.entity;
+
+
+import java.time.LocalDateTime;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -8,21 +11,22 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
-import java.time.LocalDateTime;
+import com.safetyreport.global.entity.BaseTimeEntity;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class PhotoEntity {
+@Table(name = "photo")
+public class PhotoEntity extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long id;
+    private Long id;
 
-    @Column(name = "photo_url")
-    public String photoUrl;
+    @Column(name = "photo_url", nullable = false)
+    private String photoUrl;
 
-    @Column(name = "created_at")
-    public LocalDateTime createdAt = LocalDateTime.now();
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
 
     @ManyToOne(targetEntity = UserEntity.class, fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -30,10 +34,10 @@ public class PhotoEntity {
     private UserEntity userEntity;
 
     @Builder
-    public PhotoEntity(LocalDateTime createdAt, Long id, String photoUrl, UserEntity userEntity) {
-        this.createdAt = createdAt;
+    public PhotoEntity(Long id, String photoUrl, LocalDateTime createdAt, UserEntity userEntity) {
         this.id = id;
         this.photoUrl = photoUrl;
+        this.createdAt = createdAt;
         this.userEntity = userEntity;
     }
 }

--- a/src/main/java/com/safetyreport/domain/entity/ReportEntity.java
+++ b/src/main/java/com/safetyreport/domain/entity/ReportEntity.java
@@ -1,6 +1,8 @@
-package com.safetyreport.safetyreport.domain.entity;
+package com.safetyreport.domain.entity;
 
-import com.safetyreport.safetyreport.domain.Category;
+import com.safetyreport.domain.entity.enums.CategoryEnum;
+import com.safetyreport.global.entity.BaseTimeEntity;
+
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -14,25 +16,28 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class ReportEntity {
+@Table(name = "report")
+public class ReportEntity extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long id;
+    @Column(name = "id")
+    private Long id;
 
-    @Column
-    public String content;
+    @Column(name = "content", nullable = false)
+    private String content;
 
-    @Column
-    public String address;
+    @Column(name = "address", nullable = false)
+    private String address;
 
-    @Column(name = "phone_number")
-    public String phoneNumber;
+    @Column(name = "phone_number", nullable = false)
+    private String phoneNumber;
 
     @Enumerated(EnumType.STRING)
-    public Category category = Category.PARKING;
+    @Column(name = "category", nullable = false)
+    private CategoryEnum categoryEnum = CategoryEnum.PARKING;
 
-    @Column(name = "created_at")
-    public LocalDateTime createdAt = LocalDateTime.now();
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
 
     @ManyToOne(targetEntity = UserEntity.class, fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -45,9 +50,9 @@ public class ReportEntity {
     private PhotoEntity photoEntity;
 
     @Builder
-    public ReportEntity(String address, Category category, String content, LocalDateTime createdAt, Long id, String phoneNumber, PhotoEntity photoEntity, UserEntity userEntity) {
+    public ReportEntity(String address, CategoryEnum categoryEnum, String content, LocalDateTime createdAt, Long id, String phoneNumber, PhotoEntity photoEntity, UserEntity userEntity) {
         this.address = address;
-        this.category = category;
+        this.categoryEnum = categoryEnum;
         this.content = content;
         this.createdAt = createdAt;
         this.id = id;

--- a/src/main/java/com/safetyreport/domain/entity/UserEntity.java
+++ b/src/main/java/com/safetyreport/domain/entity/UserEntity.java
@@ -1,4 +1,4 @@
-package com.safetyreport.safetyreport.domain.entity;
+package com.safetyreport.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -8,22 +8,26 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+import com.safetyreport.global.entity.BaseTimeEntity;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Table(name = "user")
 public class UserEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long id;
+    @Column(name = "id")
+    private Long id;
 
-    @Column(name = "year_report_count")
-    public int yearReportCount;
+    @Column(name = "year_report_count", nullable = false)
+    private int yearReportCount;
 
-    @Column(name = "month_report_count")
-    public int monthReportCount;
+    @Column(name = "month_report_count", nullable = false)
+    private int monthReportCount;
 
-    @Column
-    public int mileage;
+    @Column(name = "mileage", nullable = false)
+    private int mileage;
 
     @Builder
     public UserEntity(Long id, int mileage, int monthReportCount, int yearReportCount) {

--- a/src/main/java/com/safetyreport/domain/entity/enums/CategoryEnum.java
+++ b/src/main/java/com/safetyreport/domain/entity/enums/CategoryEnum.java
@@ -1,9 +1,9 @@
-package com.safetyreport.safetyreport.domain;
+package com.safetyreport.domain.entity.enums;
 
 import lombok.Getter;
 
 @Getter
-public enum Category {
+public enum CategoryEnum {
     SAFETY("안전"),
     PARKING("불법주정차"),
     TRAFFIC("교통위반"),
@@ -11,7 +11,7 @@ public enum Category {
 
     public final String description;
 
-    Category(String description) {
+    CategoryEnum(String description) {
         this.description = description;
     }
 }

--- a/src/main/java/com/safetyreport/domain/mapper/BannerMapper.java
+++ b/src/main/java/com/safetyreport/domain/mapper/BannerMapper.java
@@ -1,0 +1,17 @@
+package com.safetyreport.domain.mapper;
+
+import com.safetyreport.domain.entity.BannerEntity;
+import com.safetyreport.domain.service.domain.Banner;
+
+public class BannerMapper {
+	public static Banner toDomain(BannerEntity entity) {
+		return new Banner(entity.getId(), entity.getBannerUrl());
+	}
+
+	public static BannerEntity toEntity(Banner domain) {
+		return BannerEntity.builder()
+			.id(domain.getId())
+			.bannerUrl(domain.getBannerUrl())
+			.build();
+	}
+}

--- a/src/main/java/com/safetyreport/domain/mapper/CategoryMapper.java
+++ b/src/main/java/com/safetyreport/domain/mapper/CategoryMapper.java
@@ -1,0 +1,14 @@
+package com.safetyreport.domain.mapper;
+
+import com.safetyreport.domain.entity.CategoryEntity;
+import com.safetyreport.domain.service.domain.Category;
+
+public class CategoryMapper {
+	public static Category toDomain(CategoryEntity entity) {
+		return new Category(entity.getId(), entity.getName(), entity.getDescription());
+	}
+
+	public static CategoryEntity toEntity(Category domain) {
+		return new CategoryEntity(domain.getDescription(), domain.getId(), domain.getName());
+	}
+}

--- a/src/main/java/com/safetyreport/domain/mapper/PhotoMapper.java
+++ b/src/main/java/com/safetyreport/domain/mapper/PhotoMapper.java
@@ -1,0 +1,24 @@
+package com.safetyreport.domain.mapper;
+
+import com.safetyreport.domain.entity.PhotoEntity;
+import com.safetyreport.domain.service.domain.Photo;
+
+public class PhotoMapper {
+	public static Photo toDomain(PhotoEntity entity) {
+		return new Photo(
+			entity.getId(),
+			entity.getPhotoUrl(),
+			entity.getCreatedAt(),
+			UserMapper.toDomain(entity.getUserEntity())
+		);
+	}
+
+	public static PhotoEntity toEntity(Photo domain) {
+		return PhotoEntity.builder()
+			.id(domain.getId())
+			.photoUrl(domain.getPhotoUrl())
+			.createdAt(domain.getCreatedAt())
+			.userEntity(UserMapper.toEntity(domain.getUser()))
+			.build();
+	}
+}

--- a/src/main/java/com/safetyreport/domain/mapper/ReportMapper.java
+++ b/src/main/java/com/safetyreport/domain/mapper/ReportMapper.java
@@ -1,0 +1,32 @@
+package com.safetyreport.domain.mapper;
+
+import com.safetyreport.domain.entity.ReportEntity;
+import com.safetyreport.domain.service.domain.Report;
+
+public class ReportMapper {
+	public static Report toDomain(ReportEntity entity) {
+		return new Report(
+			entity.getId(),
+			entity.getContent(),
+			entity.getAddress(),
+			entity.getPhoneNumber(),
+			entity.getCategoryEnum(),
+			entity.getCreatedAt(),
+			UserMapper.toDomain(entity.getUserEntity()),
+			PhotoMapper.toDomain(entity.getPhotoEntity())
+		);
+	}
+
+	public static ReportEntity toEntity(Report domain) {
+		return ReportEntity.builder()
+			.id(domain.getId())
+			.content(domain.getContent())
+			.address(domain.getAddress())
+			.phoneNumber(domain.getPhoneNumber())
+			.categoryEnum(domain.getCategoryEnum())
+			.createdAt(domain.getCreatedAt())
+			.userEntity(UserMapper.toEntity(domain.getUser()))
+			.photoEntity(PhotoMapper.toEntity(domain.getPhoto()))
+			.build();
+	}
+}

--- a/src/main/java/com/safetyreport/domain/mapper/UserMapper.java
+++ b/src/main/java/com/safetyreport/domain/mapper/UserMapper.java
@@ -1,0 +1,24 @@
+package com.safetyreport.domain.mapper;
+
+import com.safetyreport.domain.entity.UserEntity;
+import com.safetyreport.domain.service.domain.User;
+
+public class UserMapper {
+	public static User toDomain(UserEntity entity) {
+		return new User(
+			entity.getId(),
+			entity.getYearReportCount(),
+			entity.getMonthReportCount(),
+			entity.getMileage()
+		);
+	}
+
+	public static UserEntity toEntity(User domain) {
+		return UserEntity.builder()
+			.id(domain.getId())
+			.yearReportCount(domain.getYearReportCount())
+			.monthReportCount(domain.getMonthReportCount())
+			.mileage(domain.getMileage())
+			.build();
+	}
+}

--- a/src/main/java/com/safetyreport/domain/repository/BannerRepository.java
+++ b/src/main/java/com/safetyreport/domain/repository/BannerRepository.java
@@ -1,0 +1,9 @@
+package com.safetyreport.domain.repository;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.safetyreport.domain.entity.BannerEntity;
+
+public interface BannerRepository extends JpaRepository<BannerEntity, Long> {
+}

--- a/src/main/java/com/safetyreport/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/safetyreport/domain/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package com.safetyreport.domain.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.safetyreport.domain.entity.CategoryEntity;
+
+public interface CategoryRepository extends JpaRepository<CategoryEntity, Long> {
+}

--- a/src/main/java/com/safetyreport/domain/repository/PhotoRepository.java
+++ b/src/main/java/com/safetyreport/domain/repository/PhotoRepository.java
@@ -1,0 +1,11 @@
+package com.safetyreport.domain.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.safetyreport.domain.entity.PhotoEntity;
+
+public interface PhotoRepository extends JpaRepository<PhotoEntity, Long> {
+	List<PhotoEntity> findAllByUserEntityId(Long userId);
+}

--- a/src/main/java/com/safetyreport/domain/repository/ReportRepository.java
+++ b/src/main/java/com/safetyreport/domain/repository/ReportRepository.java
@@ -1,0 +1,8 @@
+package com.safetyreport.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.safetyreport.domain.entity.ReportEntity;
+
+public interface ReportRepository extends JpaRepository<ReportEntity, Long> {
+}

--- a/src/main/java/com/safetyreport/domain/repository/UserRepository.java
+++ b/src/main/java/com/safetyreport/domain/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.safetyreport.domain.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.safetyreport.domain.entity.UserEntity;
+
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+}

--- a/src/main/java/com/safetyreport/domain/service/ReportService.java
+++ b/src/main/java/com/safetyreport/domain/service/ReportService.java
@@ -1,0 +1,56 @@
+package com.safetyreport.domain.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.safetyreport.domain.entity.CategoryEntity;
+import com.safetyreport.domain.entity.PhotoEntity;
+import com.safetyreport.domain.mapper.CategoryMapper;
+import com.safetyreport.domain.mapper.PhotoMapper;
+import com.safetyreport.domain.repository.CategoryRepository;
+import com.safetyreport.domain.repository.PhotoRepository;
+import com.safetyreport.domain.repository.UserRepository;
+import com.safetyreport.domain.service.domain.Category;
+import com.safetyreport.domain.service.domain.Photo;
+import com.safetyreport.global.exception.BusinessException;
+import com.safetyreport.global.exception.code.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+	private final UserRepository userRepository;
+	private final CategoryRepository categoryRepository;
+	private final PhotoRepository photoRepository;
+
+	@Transactional(readOnly = true)
+	public List<Category> getCategoryList() {
+		List<CategoryEntity> categoryEntityList = categoryRepository.findAll();
+		if (categoryEntityList.isEmpty()) {
+			throw new BusinessException(ErrorCode.DATA_NOT_FOUND);
+		}
+
+		return categoryEntityList.stream()
+			.map(CategoryMapper::toDomain)
+			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public List<Photo> getPhotoList(Long userId) {
+		userRepository.findById(userId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+		List<PhotoEntity> photoEntityList = photoRepository.findAllByUserEntityId(userId);
+		if (photoEntityList.isEmpty()) {
+			throw new BusinessException(ErrorCode.DATA_NOT_FOUND);
+		}
+
+		return photoEntityList.stream()
+			.map(PhotoMapper::toDomain)
+			.toList();
+	}
+}

--- a/src/main/java/com/safetyreport/domain/service/domain/Banner.java
+++ b/src/main/java/com/safetyreport/domain/service/domain/Banner.java
@@ -1,0 +1,19 @@
+package com.safetyreport.domain.service.domain;
+
+public class Banner {
+	private final long id;
+	private final String bannerUrl;
+
+	public Banner(long id, String bannerUrl) {
+		this.id = id;
+		this.bannerUrl = bannerUrl;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public String getBannerUrl() {
+		return bannerUrl;
+	}
+}

--- a/src/main/java/com/safetyreport/domain/service/domain/Category.java
+++ b/src/main/java/com/safetyreport/domain/service/domain/Category.java
@@ -1,0 +1,25 @@
+package com.safetyreport.domain.service.domain;
+
+public class Category {
+	private final long id;
+	private final String name;
+	private final String description;
+
+	public Category(long id, String name, String description) {
+		this.id = id;
+		this.name = name;
+		this.description = description;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+}

--- a/src/main/java/com/safetyreport/domain/service/domain/Photo.java
+++ b/src/main/java/com/safetyreport/domain/service/domain/Photo.java
@@ -1,0 +1,33 @@
+package com.safetyreport.domain.service.domain;
+
+import java.time.LocalDateTime;
+
+public class Photo {
+	private final long id;
+	private final String photoUrl;
+	private final LocalDateTime createdAt;
+	private final User user;
+
+	public Photo(long id, String photoUrl, LocalDateTime createdAt, User user) {
+		this.id = id;
+		this.photoUrl = photoUrl;
+		this.createdAt = createdAt;
+		this.user = user;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public String getPhotoUrl() {
+		return photoUrl;
+	}
+
+	public LocalDateTime getCreatedAt() {
+		return createdAt;
+	}
+
+	public User getUser() {
+		return user;
+	}
+}

--- a/src/main/java/com/safetyreport/domain/service/domain/Report.java
+++ b/src/main/java/com/safetyreport/domain/service/domain/Report.java
@@ -1,0 +1,59 @@
+package com.safetyreport.domain.service.domain;
+
+import java.time.LocalDateTime;
+
+import com.safetyreport.domain.entity.enums.CategoryEnum;
+
+public class Report {
+	private final long id;
+	private final String content;
+	private final String address;
+	private final String phoneNumber;
+	private final CategoryEnum categoryEnum;
+	private final LocalDateTime createdAt;
+	private final User user;
+	private final Photo photo;
+
+	public Report(long id, String content, String address, String phoneNumber, CategoryEnum categoryEnum, LocalDateTime createdAt, User user, Photo photo) {
+		this.id = id;
+		this.content = content;
+		this.address = address;
+		this.phoneNumber = phoneNumber;
+		this.categoryEnum = categoryEnum;
+		this.createdAt = createdAt;
+		this.user = user;
+		this.photo = photo;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public String getAddress() {
+		return address;
+	}
+
+	public String getPhoneNumber() {
+		return phoneNumber;
+	}
+
+	public CategoryEnum getCategoryEnum() {
+		return categoryEnum;
+	}
+
+	public LocalDateTime getCreatedAt() {
+		return createdAt;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	public Photo getPhoto() {
+		return photo;
+	}
+}

--- a/src/main/java/com/safetyreport/domain/service/domain/User.java
+++ b/src/main/java/com/safetyreport/domain/service/domain/User.java
@@ -1,0 +1,31 @@
+package com.safetyreport.domain.service.domain;
+
+public class User {
+	private final long id;
+	private final int yearReportCount;
+	private final int monthReportCount;
+	private final int mileage;
+
+	public User(long id, int yearReportCount, int monthReportCount, int mileage) {
+		this.id = id;
+		this.yearReportCount = yearReportCount;
+		this.monthReportCount = monthReportCount;
+		this.mileage = mileage;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public int getYearReportCount() {
+		return yearReportCount;
+	}
+
+	public int getMonthReportCount() {
+		return monthReportCount;
+	}
+
+	public int getMileage() {
+		return mileage;
+	}
+}

--- a/src/main/java/com/safetyreport/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/safetyreport/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.safetyreport.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/safetyreport/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/safetyreport/global/entity/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.safetyreport.global.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.validation.constraints.NotNull;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+	@CreatedDate
+	@NotNull
+	private LocalDateTime createdAt;
+
+	public LocalDateTime getCreatedAt() {
+		return createdAt;
+	}
+
+}

--- a/src/main/java/com/safetyreport/global/exception/BusinessException.java
+++ b/src/main/java/com/safetyreport/global/exception/BusinessException.java
@@ -1,0 +1,15 @@
+package com.safetyreport.global.exception;
+
+import com.safetyreport.global.exception.code.ErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+	private final ErrorCode errorCode;
+
+	public BusinessException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/safetyreport/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/safetyreport/global/exception/code/ErrorCode.java
@@ -1,0 +1,42 @@
+package com.safetyreport.global.exception.code;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+	/*
+	400 BAD REQUEST
+	 */
+	INVALID_FIELD_ERROR(HttpStatus.BAD_REQUEST, "요청 필드 값이 유효하지 않습니다."),
+	MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "필수 요청 파라미터가 누락되었습니다."),
+	MISSING_HEADER(HttpStatus.BAD_REQUEST, "필수 요청 헤더가 누락되었습니다."),
+	TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "요청 값 타입이 올바르지 않습니다."),
+	INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "요청 본문이 올바르지 않습니다."),
+	DATA_INTEGRITY_VIOLATION(HttpStatus.BAD_REQUEST, "데이터 무결성 제약 조건을 위반했습니다."),
+	BUSINESS_LOGIC_ERROR(HttpStatus.BAD_REQUEST, "비즈니스 로직 처리 중 오류가 발생했습니다."),
+
+	/*
+	 404 NOT FOUND
+	 */
+	DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "데이터가 존재하지 않습니다"),
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저가 존재하지 않습니다"),
+
+	/*
+	 500 INTERNAL SERVER ERROR
+	 */
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 오류가 발생했습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	public HttpStatus getHttpStatus() {
+		return httpStatus;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/com/safetyreport/global/exception/code/SuccessCode.java
+++ b/src/main/java/com/safetyreport/global/exception/code/SuccessCode.java
@@ -1,0 +1,31 @@
+package com.safetyreport.global.exception.code;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum SuccessCode {
+
+	/*
+	201 CREATED
+	 */
+	SUCCESS_CREATE(HttpStatus.CREATED, "생성이 완료되었습니다."),
+
+	/*
+	200 OK
+	 */
+	SUCCESS_UPDATE(HttpStatus.OK, "업데이트가 완료되었습니다."),
+	SUCCESS_DELETE(HttpStatus.OK, "삭제가 완료되었습니다."),
+	SUCCESS_FETCH(HttpStatus.OK, "요청 데이터가 성공적으로 조회되었습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	public HttpStatus getHttpStatus() {
+		return httpStatus;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/com/safetyreport/global/exception/dto/ErrorResponse.java
+++ b/src/main/java/com/safetyreport/global/exception/dto/ErrorResponse.java
@@ -1,0 +1,83 @@
+package com.safetyreport.global.exception.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.safetyreport.global.exception.code.ErrorCode;
+
+import jakarta.validation.ConstraintViolation;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+import java.util.Set;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ErrorResponse(
+	int status,
+	String message,
+	List<ValidationError> errors
+) {
+	// 에러 응답 (유효성 검사 없음, ErrorCode 메시지만 표시)
+	public static ErrorResponse of(ErrorCode errorCode) {
+		return new ErrorResponse(
+			errorCode.getHttpStatus().value(),
+			errorCode.getMessage(),
+			null
+		);
+	}
+
+	// 에러 응답 (유효성 검사 포함)
+	public static ErrorResponse of(ErrorCode errorCode, BindingResult bindingResult) {
+		return new ErrorResponse(
+			errorCode.getHttpStatus().value(),
+			errorCode.getMessage(),
+			ValidationError.of(bindingResult)
+		);
+	}
+
+	// 에러 응답 (ConstraintViolation 포함)
+	public static ErrorResponse of(ErrorCode errorCode, Set<ConstraintViolation<?>> violations) {
+		return new ErrorResponse(
+			errorCode.getHttpStatus().value(),
+			errorCode.getMessage(),
+			ValidationError.of(violations)
+		);
+	}
+
+	// 에러 응답 (추가 세부 정보 포함)
+	public static ErrorResponse of(ErrorCode errorCode, Object detail) {
+		return new ErrorResponse(
+			errorCode.getHttpStatus().value(),
+			errorCode.getMessage() + (detail != null ? ": " + detail : ""),
+			null
+		);
+	}
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record ValidationError(
+		String path,
+		String field,
+		String message
+	) {
+		// ConstraintViolation -> ValidationError 변환
+		public static List<ValidationError> of(Set<ConstraintViolation<?>> violations) {
+			return violations == null ? List.of() : violations.stream()
+				.map(violation -> new ValidationError(
+					violation.getPropertyPath().toString(),
+					null,
+					violation.getMessage()
+				))
+				.toList();
+		}
+
+		// FieldError -> ValidationError 변환
+		public static List<ValidationError> of(BindingResult bindingResult) {
+			return bindingResult.getFieldErrors().stream()
+				.map(error -> new ValidationError(
+					null,
+					error.getField(),
+					error.getDefaultMessage()
+				))
+				.toList();
+		}
+	}
+}

--- a/src/main/java/com/safetyreport/global/exception/dto/SuccessResponse.java
+++ b/src/main/java/com/safetyreport/global/exception/dto/SuccessResponse.java
@@ -1,0 +1,23 @@
+package com.safetyreport.global.exception.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.safetyreport.global.exception.code.SuccessCode;
+
+@JsonPropertyOrder({"status", "message", "data"})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SuccessResponse<T>(
+	int status,
+	String message,
+	T data
+) {
+	// 성공 응답 (데이터 없음)
+	public static <T> SuccessResponse<T> of(SuccessCode successCode) {
+		return new SuccessResponse<>(successCode.getHttpStatus().value(), successCode.getMessage(), null);
+	}
+
+	// 성공 응답 (데이터 있음)
+	public static <T> SuccessResponse<T> of(SuccessCode successCode, T data) {
+		return new SuccessResponse<>(successCode.getHttpStatus().value(), successCode.getMessage(), data);
+	}
+}

--- a/src/main/java/com/safetyreport/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/safetyreport/global/handler/GlobalExceptionHandler.java
@@ -1,0 +1,75 @@
+package com.safetyreport.global.handler;
+
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+
+import com.safetyreport.global.exception.BusinessException;
+import com.safetyreport.global.exception.code.ErrorCode;
+import com.safetyreport.global.exception.dto.ErrorResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(BusinessException.class)
+	public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+		return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+			.body(ErrorResponse.of(e.getErrorCode()));
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+		return buildErrorResponse(ErrorCode.INVALID_FIELD_ERROR, e.getBindingResult());
+	}
+
+	@ExceptionHandler(ConstraintViolationException.class)
+	public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
+		return buildErrorResponse(ErrorCode.INVALID_FIELD_ERROR, e.getMessage());
+	}
+
+	@ExceptionHandler(MissingServletRequestParameterException.class)
+	public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+		return buildErrorResponse(ErrorCode.MISSING_PARAMETER, e.getParameterName());
+	}
+
+	@ExceptionHandler(MissingRequestHeaderException.class)
+	public ResponseEntity<ErrorResponse> handleMissingRequestHeaderException(MissingRequestHeaderException e) {
+		return buildErrorResponse(ErrorCode.MISSING_HEADER, e.getHeaderName());
+	}
+
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<ErrorResponse> handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
+		String detail = e.getRequiredType() != null
+			? String.format("'%s'은(는) %s 타입이어야 합니다.", e.getName(), e.getRequiredType().getSimpleName())
+			: "타입 변환 오류입니다.";
+		return buildErrorResponse(ErrorCode.TYPE_MISMATCH, detail);
+	}
+
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+		return buildErrorResponse(ErrorCode.INVALID_REQUEST_BODY, e.getMessage());
+	}
+
+	@ExceptionHandler(DataIntegrityViolationException.class)
+	public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+		return buildErrorResponse(ErrorCode.DATA_INTEGRITY_VIOLATION, e.getMessage());
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleGeneralException(Exception e) {
+		return buildErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
+	}
+
+	private ResponseEntity<ErrorResponse> buildErrorResponse(ErrorCode errorCode, Object detail) {
+		return ResponseEntity.status(errorCode.getHttpStatus())
+			.body(ErrorResponse.of(errorCode, detail));
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=safetyreport

--- a/src/test/java/com/safetyreport/SafetyreportApplicationTests.java
+++ b/src/test/java/com/safetyreport/SafetyreportApplicationTests.java
@@ -1,4 +1,4 @@
-package com.safetyreport.safetyreport;
+package com.safetyreport;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
# 💡 Issue
- resolved: #7 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
## 커스텀 응답 및 예외 처리
- ErrorResponse, SuccessResponse를 이용해 다양한 상황의 응답 형태를 정의했습니다. 아래의 스크린샷들을 통해 예시 확인해주세요!
- GlobalExceptionHandler로 다양한 예외 발생 상황을 핸들링 했고 ErrorCode, SuccessCode로 다양한 성공/예외 응답 코드와 message를 정의했습니다.

## 프로젝트 세팅 수정
- build.gradle에 의존성 수정 부분이 있으니 반드시 pull 후 `gradle projects reload` 해주세요!
- `application.yml, application-local.yml`은 `노션`에서 확인 부탁드립니다.
- JpaAuditingConfig, BaseTimeEntity도 생성했습니다.

## API 구현 방식
- 엔티티 클래스(ex. PhotoEntity)와 도메인 클래스(ex. Photo)를 분리했습니다.
    - service에서 repository를 통해 엔티티를 가져옵니다.
    - 해당 엔티티는 service에서 Mapper 클래스를 통해 도메인으로 변환됩니다.
    - service에서 변환된 객체를 controller로 넘깁니다.
    - controller에서 해당 객체를 클라이언트에게 전달할 dto로 변환해 api 요청에 응답합니다.
코드를 따라가며 보시면 더 잘 이해하실 수 있을거에요!

## 신고 카테고리 설명 GET API 구현
### 성공
<img width="821" alt="image" src="https://github.com/user-attachments/assets/8813b906-d75d-4f04-8c95-e024455bb72b">

### 실패 - 틀린 url로 요청시
<img width="824" alt="image" src="https://github.com/user-attachments/assets/31656c56-995c-46c1-9591-d517fec4b20a">

### 실패 - 카테고리 데이터가 존재하지 않을 시
<img width="823" alt="image" src="https://github.com/user-attachments/assets/41b14183-fee1-4032-a91d-0bd0e034142c">

## 갤러리 GET API 구현
### 성공
<img width="825" alt="image" src="https://github.com/user-attachments/assets/2cb22719-3be0-4c75-bf1c-71b39d0f704e">

### 실패 - 존재하지 않는 유저로 조회 시
<img width="819" alt="image" src="https://github.com/user-attachments/assets/ecb6fb19-1128-4f3f-b968-3c00785968a9">

### 실패 - request header 누락 시
<img width="821" alt="image" src="https://github.com/user-attachments/assets/e02d5431-3cec-4df2-99cb-044466b7006d">

# 💬 To Reviewers
<!-- 리뷰어들에게 남기고 싶은 말을 적어주세요
ex) 코드 리뷰 간 참고사항, 질문 등 -->
- 환경 구성 및 테스트를 위해 부득이하게 하나의 브랜치에 많은 커밋을 남기게 된 점.. 양해 부탁드립니다🥲🥲
- 궁금하신 점이나 수정하면 좋을 것 같은 점 말씀해주세요~